### PR TITLE
Make PyAudio an optional dependency to prevent pip errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,12 @@ setup(
 		],
 	install_requires=[
 		'numpy',
-		'PyAudio', # tests and examples
 	],
 	test_suite='test',
+	tests_require='PyAudio',
+	extras_require={
+		"examples":"PyAudio"
+	},
 	classifiers = [
 		'Programming Language :: Python',
 		'Programming Language :: Python :: 2',


### PR DESCRIPTION
Hello again David :-)

I started [another project](https://github.com/j3ffhubb/python-mix) that uses your module, but the PyAudio dependency makes distributing it via Pip somewhat problematic.  The commit message below describes the problem and the solution.

----Commit Message----

Installing PyAudio via pip on a clean install of Fedora 22 (and likely most or all other distros) gives this error if the user does not already have PyAudio installed:

```
Collecting PyAudio (from wavefile)
  Could not find a version that satisfies the requirement PyAudio
(from wavefile) (from versions: )
  Some externally hosted files were ignored as access to them may be
unreliable (use --allow-external PyAudio to allow).
No matching distribution found for PyAudio (from wavefile)
```

This patch makes the examples and test suite features depend on PyAudio, but does not require PyAudio to install python-wavefile.