### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Wish list
 Installation
 ------------
 
-[![Latest Version](https://pypip.in/version/wavefile/badge.svg)](https://pypi.python.org/pypi/wavefile/)
-[![Supported Python Versions](https://pypip.in/py_versions/wavefile/badge.svg)](https://pypi.python.org/pypi/wavefile/)
+[![Latest Version](https://img.shields.io/pypi/v/wavefile.svg)](https://pypi.python.org/pypi/wavefile/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/wavefile.svg)](https://pypi.python.org/pypi/wavefile/)
 
 ### Binary dependencies
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20wavefile))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `wavefile`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.