### PR TITLE
replace StopIteration by return due to deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: required
+dist: xenial
 python:
 - "2.7"
 - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y libsndfile1 portaudio19-dev
 install:
-- pip install --allow-external PyAudio --allow-unverified PyAudio PyAudio
+- pip install PyAudio
 - pip install numpy
 - pip install coveralls
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-- "2.6"
 - "2.7"
-#- "3.2" # coverage broke compatibility, python-wavefile is still compatible
 - "3.3"
 - "3.4"
+- "3.5"
+- "3.6"
+- "3.7"
 script: coverage run --source wavefile ./setup.py test
 before_install:
 - sudo apt-get update -qq
@@ -15,5 +16,3 @@ install:
 - pip install coveralls
 after_success:
 - coveralls
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: xenial
 python:
 - "2.7"
-- "3.3"
 - "3.4"
 - "3.5"
 - "3.6"

--- a/wavefile/wavefile.py
+++ b/wavefile/wavefile.py
@@ -286,7 +286,7 @@ class WaveReader(object) :
         while nframes :
             yield data[:,:nframes]
             nframes = self.read(data)
-        raise StopIteration
+        return
 
     def buffer(self, size, dtype=np.float32) :
         """Provides a properly constructed buffer to read data"""


### PR DESCRIPTION
See [PEP 479](https://www.python.org/dev/peps/pep-0479/) for details. The StopIteration raises a DepracationWarning with recent Python versions.